### PR TITLE
Set up the Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: python3 -m pip install -U pip coverage
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
             coverage run test_add_number.py
             coverage xml
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Thanks for great talk! :clap: https://www.youtube.com/watch?v=vLBr_AfomUY&ab_channel=DataUmbrella

We need to use `actions/setup-python` to set up the Python version, otherwise it'll use whatever the default version is (happens to be 3.8 at the moment).

Also let's use `v2` of https://github.com/marketplace/actions/codecov because `v1` is deprecated and will be removed next year.